### PR TITLE
you might load this request regarding update the snapshot build to the stable 7.27.0 version

### DIFF
--- a/with-https-darwinssl/01-build-libcurl.sh
+++ b/with-https-darwinssl/01-build-libcurl.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VERSION="7.27.0-20120723"
+VERSION="7.27.0"
 LIBNAME="libcurl"
-LIBDOWNLOAD="http://curl.haxx.se/snapshots/curl-${VERSION}.tar.gz"
+LIBDOWNLOAD="http://curl.haxx.se/download/curl-${VERSION}.tar.gz"
 ARCHIVE="${LIBNAME}-${VERSION}.tar.gz"
 
 # Enabled/disabled protocols (the fewer, the smaller the final binary size)


### PR DESCRIPTION
darwinssl is now stable in curl 7.27.0

Signed-off-by: Jonas Schnelli jonas.schnelli@include7.ch
