### PR TITLE
--sdk-version command line argument should accept a parameter

### DIFF
--- a/lib/curl_builder/parser.rb
+++ b/lib/curl_builder/parser.rb
@@ -73,7 +73,7 @@ module CurlBuilder
           end
         end
 
-        parser.on('--sdk-version',
+        parser.on('--sdk-version SDK',
                   'Use specific SDK version',
                   "  Defaults to #{param(setup[:sdk_version])}") do |sdk|
           setup[:sdk_version] = sdk


### PR DESCRIPTION
--sdk-version was interpreted just as a flag argument and any parameter didn't have any effect. I guess this is how it's supposed to be.
