### PR TITLE
Changed newer Ruby syntax to 1.8 compliant

### DIFF
--- a/build_curl
+++ b/build_curl
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
-require_relative 'lib/curl_builder'
+
+$: << "lib"
+require 'curl_builder'
 
 module CurlBuilder
   class Orchestrator
@@ -12,12 +14,12 @@ module CurlBuilder
       CurlBuilder.logger.level = Logger.const_get(configuration[:setup][:log_level].upcase.to_sym)
 
       # Start building
-      Preparer.new(configuration: configuration).prepare
-      compiled_archs = Compiler.new(configuration: configuration).compile
+      Preparer.new(:configuration => configuration).prepare
+      compiled_archs = Compiler.new(:configuration => configuration).compile
       error { 'Compilation failed for all requested architectures.' } if compiled_archs.empty?
       return if compiled_archs.empty?
 
-      packed = Packer.new(configuration: configuration).pack(compiled_archs)
+      packed = Packer.new(:configuration => configuration).pack(compiled_archs)
       if packed.empty?
         error { 'Unable to pack any of the output binaries' }
         error { "To determine the cause, please run again with '#{param('--log-level debug --verbose')}'." }
@@ -29,7 +31,7 @@ module CurlBuilder
     rescue Errors::TaskError => e
       error { "Build failed, output follows:\n#{black('----')}\n#{gray(e.message)}\n#{black('----')}" }
     ensure
-      Cleaner.new(configuration: configuration).cleanup unless configuration.nil?
+      Cleaner.new(:configuration => configuration).cleanup unless configuration.nil?
     end
 
     def log_id

--- a/lib/curl_builder.rb
+++ b/lib/curl_builder.rb
@@ -4,17 +4,17 @@ require 'fileutils'
 require 'open3'
 
 
-require_relative 'curl_builder/errors'
-require_relative 'curl_builder/paths'
-require_relative 'curl_builder/logging'
-require_relative 'curl_builder/configurable_step'
+require 'curl_builder/errors'
+require 'curl_builder/paths'
+require 'curl_builder/logging'
+require 'curl_builder/configurable_step'
 
 # Steps
-require_relative 'curl_builder/parser'
-require_relative 'curl_builder/preparer'
-require_relative 'curl_builder/compiler'
-require_relative 'curl_builder/packer'
-require_relative 'curl_builder/cleaner'
+require 'curl_builder/parser'
+require 'curl_builder/preparer'
+require 'curl_builder/compiler'
+require 'curl_builder/packer'
+require 'curl_builder/cleaner'
 
 
 # Phases
@@ -57,21 +57,21 @@ module CurlBuilder
   }
 
   DEFAULT_SETUP = {
-    log_level:          'info', # debug, info, warn, error
-    verbose:            false,
-    sdk_version:        '6.0',
-    libcurl_version:    '7.27.0',
-    architectures:      %w(i386 armv7 armv7s),
-    xcode_home:         '/Applications/Xcode.app/Contents/Developer',
-    run_on_dir:         Dir::pwd,
-    work_dir:           'build',
-    result_dir:         'curl',
-    clean_and_exit:     false,
-    cleanup:            true,
+    :log_level =>       'info', # debug, info, warn, error
+    :verbose =>         false,
+    :sdk_version =>     '6.0',
+    :libcurl_version => '7.27.0',
+    :architectures =>   %w(i386 armv7 armv7s),
+    :xcode_home =>      '/Applications/Xcode.app/Contents/Developer',
+    :run_on_dir =>      Dir::pwd,
+    :work_dir =>        'build',
+    :result_dir =>      'curl',
+    :clean_and_exit =>  false,
+    :cleanup =>         true,
   }
 
   VALID_ARGS = {
-    architectures: %w(i386 armv6 armv7 armv7s)
+    :architectures => %w(i386 armv6 armv7 armv7s)
   }
 
 

--- a/lib/curl_builder/compiler.rb
+++ b/lib/curl_builder/compiler.rb
@@ -65,12 +65,12 @@ module CurlBuilder
 
     def tools_for(platform)
       {
-        cc:     find_tool('llvm-gcc-4.2', platform),
-        ld:     find_tool('ld', platform),
-        ar:     find_tool('ar', platform),
-        as:     find_tool('as', platform),
-        nm:     find_tool('nm', platform),
-        ranlib: find_tool('ranlib', platform)
+        :cc =>     find_tool('llvm-gcc-4.2', platform),
+        :ld =>     find_tool('ld', platform),
+        :ar =>     find_tool('ar', platform),
+        :as =>     find_tool('as', platform),
+        :nm =>     find_tool('nm', platform),
+        :ranlib => find_tool('ranlib', platform)
       }
     end
 
@@ -85,8 +85,8 @@ module CurlBuilder
       sdk = "#{setup(:xcode_home)}/Platforms/#{platform}.platform/Developer/SDKs/#{platform}#{setup(:sdk_version)}.sdk"
 
       {
-        ldflags: "-arch #{architecture} -pipe -isysroot #{sdk}",
-        cflags:  "-arch #{architecture} -pipe -isysroot #{sdk}"
+        :ldflags => "-arch #{architecture} -pipe -isysroot #{sdk}",
+        :cflags =>  "-arch #{architecture} -pipe -isysroot #{sdk}"
       }
     end
 

--- a/lib/curl_builder/parser.rb
+++ b/lib/curl_builder/parser.rb
@@ -58,7 +58,7 @@ module CurlBuilder
         parser.on('--enable-protocols A,B,C',
                   Array,
                   'Enables a list of protocols',
-                  "  Defaults to #{param(protocols.select { |k, enabled| enabled }.keys.join(', '))}") do |enabled|
+                  "  Defaults to #{param(Hash[protocols.select { |k, enabled| enabled }].keys.join(', '))}") do |enabled|
           enabled.each do |p|
             protocols[p] = true
           end
@@ -67,7 +67,7 @@ module CurlBuilder
         parser.on('--disable-protocols A,B,C',
                   Array,
                   'Disables a list of protocols',
-                  "  Defaults to #{param(protocols.select { |k, enabled| !enabled }.keys.join(', '))}") do |enabled|
+                  "  Defaults to #{param(Hash[protocols.select { |k, enabled| !enabled }].keys.join(', '))}") do |enabled|
           enabled.each do |p|
             protocols[p] = false
           end
@@ -132,7 +132,7 @@ module CurlBuilder
 
       parser.parse(args)
 
-      {setup: setup, protocols: protocols, flags: flags}
+      { :setup => setup, :protocols => protocols, :flags => flags}
     end
   end
 end


### PR DESCRIPTION
I've still got Ruby 1.8 and the script refused to execute. I needed to make some syntax modifications in order to get it run with this older Ruby version. The functionality should be exactly the same as previously.
