### PR TITLE
Fixes configure for arm64 builds

### DIFF
--- a/lib/curl_builder.rb
+++ b/lib/curl_builder.rb
@@ -64,7 +64,7 @@ module CurlBuilder
     sdk_version:        "7.0",
     osx_sdk_version:    "10.8",
     libcurl_version:    "7.32.0",
-    architectures:      %w(i386 armv7 armv7s x86_64),
+    architectures:      %w(i386 armv7 armv7s arm64 x86_64),
     xcode_home:         "/Applications/Xcode.app/Contents/Developer",
     run_on_dir:         Dir::pwd,
     work_dir:           "build",

--- a/lib/curl_builder/compiler.rb
+++ b/lib/curl_builder/compiler.rb
@@ -129,11 +129,13 @@ module CurlBuilder
       flags << "--enable-debug" if setup(:debug_symbols)
       flags << "--enable-curldebug" if setup(:curldebug)
 
+      host = architecture == "arm64" ? "aarch64-apple-darwin" : "#{architecture}-apple-darwin"
+
       configure_command = %W{
         #{expand_env_vars(tools)}
         #{expand_env_vars(compilation_flags)}
         ./configure
-        --host=#{architecture}-apple-darwin
+        --host=#{host}
         --disable-shared
         --enable-static
         #{flags.join(" ")}


### PR DESCRIPTION
configures host parameter has to be aarch64-apple-darwin instead of arm64-apple-darwin so a check is added to compiler.rb.

arm64 architecture build is now working so it is enabled by default.
