### PR TITLE
Fix XCode simulator build for XCode 6.1

### DIFF
--- a/lib/curl_builder/compiler.rb
+++ b/lib/curl_builder/compiler.rb
@@ -92,7 +92,10 @@ module CurlBuilder
     end
 
     def compilation_flags_for(platform, architecture)
-      if platform == "iPhoneOS" || platform == "iPhoneSimulator"
+      if platform == "iPhoneSimulator"
+        version = "6.0"
+        min_version = "-miphoneos-version-min=#{version}"
+      elsif platform == "iPhoneOS"
         version = architecture == "arm64" ? "6.0" : "5.0"
         min_version = "-miphoneos-version-min=#{version}"
       else


### PR DESCRIPTION
When building with XCode 6.1, the Simulator build will fail the
configure step, due to gcc checks seemingly either not pulling in
a needed library that defines an init function, or that it doesn't
explicitly define the needed init function.

To correct this, setting the minimum IOS version to 6.0 fixes this.

Of course, this limits users of the curl library to a minimum of
version 6.0.
